### PR TITLE
add typescriptreact

### DIFF
--- a/plugin/vim-printer.vim
+++ b/plugin/vim-printer.vim
@@ -16,6 +16,7 @@ let s:vim_printer_items_full = {
             \ 'javascriptreact': 'console.log("{$}:", {$})',
             \ 'javascript.jsx': 'console.log("{$}:", {$})',
             \ 'typescript': 'console.log("{$}:", {$})',
+            \ 'typescriptreact': 'console.log("{$}:", {$})',
             \ 'typescript.tsx': 'console.log("{$}:", {$})',
             \ 'go': 'fmt.Println("{$}:", {$})',
             \ 'vim': 'echo "{$}: ".{$}',


### PR DESCRIPTION
This adds `typescriptreact` as a possible file type.
I'm not sure about `typescript.tsx` and `javascript.jsx`, they may can be removed but I'm not sure on this so I left them in.

This is similiar to this commit: https://github.com/meain/vim-printer/commit/55ab49179838d86f92fd847504cef3570000b7f3